### PR TITLE
Fix issues downloading authenticated artifacts

### DIFF
--- a/JFrogArtifactoryDownloader/ArtifactoryDownload.ps1
+++ b/JFrogArtifactoryDownloader/ArtifactoryDownload.ps1
@@ -59,9 +59,13 @@ else
 
 if ($artifactoryUser) {
         Write-Host "artifactoryUser = $artifactoryUser"
+} else {
+        Write-Host "artifactoryUser = (null)"
 }
 if ($artifactoryPwd) {
         Write-Host "artifactoryPwd = (masked)"
+} else {
+        Write-Host "artifactoryPwd = (null)"
 }
 
 $body = @{}
@@ -82,7 +86,7 @@ else
     {
 		$body.buildNumber = "LATEST"
 	}
-	Write-Host "buildNumber = $body.buildNumber"
+	Write-Host "buildNumber = $($body.buildNumber)"
 }
 
 $body.archiveType = "zip"

--- a/JFrogArtifactoryDownloader/ArtifactoryDownload.ps1
+++ b/JFrogArtifactoryDownloader/ArtifactoryDownload.ps1
@@ -40,8 +40,8 @@ $artifactoryEndpoint = GetArtifactoryEndpoint $artifactoryEndpointName
 
 $artifactoryUrl = $($artifactoryEndpoint.Url)
 
-Write-Verbose "artifactoryUrl = $artifactoryUrl"
-Write-Verbose "buildName = $buildName"
+Write-Host "artifactoryUrl = $artifactoryUrl"
+Write-Host "buildName = $buildName"
 
 $overrideCredentialsChecked = Convert-String $overrideCredentials Boolean
 
@@ -57,13 +57,20 @@ else
 	$artifactoryPwd = $($artifactoryEndpoint.Authorization.Parameters.Password)
 }
 
+if ($artifactoryUser) {
+        Write-Host "artifactoryUser = $artifactoryUser"
+}
+if ($artifactoryPwd) {
+        Write-Host "artifactoryPwd = (masked)"
+}
+
 $body = @{}
 
 $body.buildName = $buildName
 if($buildStatus)
 {
     $body.buildStatus = $buildStatus
-	Write-Verbose "buildStatus = $buildStatus"
+    Write-Host "buildStatus = $buildStatus"
 } 
 else
 {
@@ -75,28 +82,28 @@ else
     {
 		$body.buildNumber = "LATEST"
 	}
-	Write-Verbose "buildNumber = $body.buildNumber"
+	Write-Host "buildNumber = $body.buildNumber"
 }
 
 $body.archiveType = "zip"
 
 $jsonBody = ConvertTo-JSON $body
 
-$secpwd = ConvertTo-SecureString $artifactoryPwd -AsPlainText -Force
-$cred = New-Object System.Management.Automation.PSCredential ($artifactoryUser, $secpwd)
 $api = [string]::Format("{0}/api/archive/buildArtifacts", $artifactoryUrl)
+
+$base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("{0}:{1}" -f $artifactoryUser, $artifactoryPwd)))
 
 $Destination = "$env:temp\artifacts.zip"
 
 try{
-		Invoke-RestMethod -Uri $api -Method Post -Credential $cred -ContentType "application/json" -Body $jsonBody -OutFile $Destination
+		Invoke-RestMethod -Uri $api -Method Post -Headers @{Authorization=("Basic {0}" -f $base64AuthInfo)} -ContentType "application/json" -Body $jsonBody -OutFile $Destination
 		if(Test-Path $Destination)
 		{
-			Write-Verbose "Archive downloaded at $Destination"
+			Write-Host "Archive downloaded at $Destination"
 		}
 		
 	}
-	catch{
+	catch {
 		Write-Verbose $_.Exception.ToString()
 		$response = $_.Exception.Response
 		$responseStream = $response.GetResponseStream()
@@ -105,5 +112,5 @@ try{
 		$streamReader.DiscardBufferedData()
 		$responseBody = $streamReader.ReadToEnd()
 		$streamReader.Close()
-		Write-Warning "Cannot get artifacts archive- $responseBody" 
+		Write-Error -Message "Cannot get artifacts archive- $responseBody" -Exception $_.Exception
 	}


### PR DESCRIPTION
I ran into some issues trying to download from our on-prem Artifactory instance. For one, the log output was not very helpful because `Write-Verbose` does not output to the VSTS log to help debug issues. Also, because an exception is written as a Warning, the step does not "fail" in VSTS, it actually gets marked as succeeded:

![image](https://cloud.githubusercontent.com/assets/563819/22268898/e4d412b6-e24e-11e6-8bbd-4bef590baad9.png)

## Changes

- Force send Basic authenticate header on initial request because otherwise Invoke-RestMethod will return 403 on authenticated resources
- Change Write-Verbose to Write-Host to see in log output in VSTS to aid debugging
- Write-Error so error and exception information is reported to VSTS (otherwise the Release step succeeds on error)

For more info regarding how initial vs. later requests act in .NET, see:

- http://stackoverflow.com/questions/24672760/powershells-invoke-restmethod-equivalent-of-curl-u-basic-authentication
- https://weblog.west-wind.com/posts/2010/Feb/18/NET-WebRequestPreAuthenticate-not-quite-what-it-sounds-like

I tested these changes on our on-prem agent and it works great.