### PR TITLE
Fix the ArtifactDeploy task failing in release management tasks.

### DIFF
--- a/JFrogArtifactoryDeployer/ArtifactoryDeploy.ps1
+++ b/JFrogArtifactoryDeployer/ArtifactoryDeploy.ps1
@@ -77,7 +77,7 @@ if((!$artifactoryCliPath) -or ((Get-Item $artifactoryCliPath) -is [System.IO.Dir
 {
     Write-Host "Downloading the JFrog cli from Bintray"
 	$source = "https://api.bintray.com/content/jfrog/jfrog-cli-go/1.4.1/jfrog-cli-windows-amd64/jfrog.exe;bt_package=jfrog-cli-windows-amd64"
-	$artifactoryCliPath = "$env:AGENT_BUILDDIRECTORY" + "\jfrog.exe"
+	$artifactoryCliPath = "$env:SYSTEM_ARTIFACTSDIRECTORY" + "\jfrog.exe"
 	Invoke-WebRequest $source -OutFile $artifactoryCliPath
 }
 


### PR DESCRIPTION
The **JFrogArtifactoryDeployer** task is failing in Release Management with the following error:

> System.UnauthorizedAccessException: Access to the path 'F:\jfrog.exe' is denied.

This happens because the environment variable AGENT_BUILDDIRECTORY was intended to use for Builds and does not exist in Release Management.
This PR changes the use of the environment variable AGENT_BUILDDIRECTORY to SYSTEM_ARTIFACTSDIRECTORY which is designed to point to AGENT_BUILDDIRECTORY for build and AGENT_RELEASEDIRECTORY in case of Release.